### PR TITLE
Added StatusCode() functionality

### DIFF
--- a/client_all.go
+++ b/client_all.go
@@ -263,6 +263,11 @@ func (cc *Client) getStatus() Status {
 
 }
 
+// StatusCode - returns the current connection status
+func (cc *Client) StatusCode() Status {
+	return cc.status
+}
+
 // Status - returns the current connection status as a string
 func (cc *Client) Status() string {
 

--- a/server_all.go
+++ b/server_all.go
@@ -303,6 +303,11 @@ func (sc *Server) getStatus() Status {
 
 }
 
+// StatusCode - returns the current connection status
+func (sc *Server) StatusCode() Status {
+	return sc.status
+}
+
 // Status - returns the current connection status as a string
 func (sc *Server) Status() string {
 


### PR DESCRIPTION
Hello,

I want to propose this minor addition: Currently, the only way to get the status as an arbitrary point in time is to use `#Status()`. This however returns only a string representation of the status, which is hard to compare to different states.

I want to use this functionality for something like this:
```
// wait for the client to connect:
for cc.StatsusCode() != ipc.Connected {
  time.Sleep(time.Second)
}
// write data:
cc.Write(5, "foo")
```
If I don't wait for the client to connect first, the data is simply voided.