### PR TITLE
Added go modules, fixed windows import

### DIFF
--- a/connect_windows.go
+++ b/connect_windows.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/microsoft/go-winio-master"
+	"github.com/Microsoft/go-winio"
 )
 
 // Server function

--- a/example/example.go
+++ b/example/example.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	ipc "../../golang-ipc"
+	ipc "golang-ipc"
 )
 
 func main() {

--- a/example/example.go
+++ b/example/example.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"time"
 
-	ipc "golang-ipc"
+	ipc "github.com/james-barrow/golang-ipc"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module golang-ipc
+
+go 1.15
+
+require github.com/Microsoft/go-winio v0.4.16 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module golang-ipc
+module github.com/james-barrow/golang-ipc
 
 go 1.15
 
-require github.com/Microsoft/go-winio v0.4.16 // indirect
+require github.com/Microsoft/go-winio v0.4.16

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
+github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
+github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3 h1:7TYNF4UdlohbFwpNH04CoPMp1cHUZgO1Ebq5r2hIjfo=
+golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Hello,

I noticed two things:
 - this library doesn't have a `go.mod` file
 - the import in the `connect_windows.go` is off: it currently is `github.com/Microsoft/go-winio-master` should be `github.com/Microsoft/go-winio` instead.

