### PR TITLE
Replace conn.Read with io.ReadFull

### DIFF
--- a/client_all.go
+++ b/client_all.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"bufio"
 	"errors"
+	"io"
 	"strings"
 	"time"
 )
@@ -124,7 +125,7 @@ func (cc *Client) read() {
 
 func (cc *Client) readData(buff []byte) bool {
 
-	_, err := cc.conn.Read(buff)
+	_, err := io.ReadFull(cc.conn, buff)
 	if err != nil {
 		if strings.Contains(err.Error(), "EOF") { // the connection has been closed by the client.
 			cc.conn.Close()

--- a/server_all.go
+++ b/server_all.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"bufio"
 	"errors"
+	"io"
 	"time"
 )
 
@@ -179,7 +180,7 @@ func (sc *Server) read() {
 
 func (sc *Server) readData(buff []byte) bool {
 
-	_, err := sc.conn.Read(buff)
+	_, err := io.ReadFull(sc.conn, buff)
 	if err != nil {
 
 		if sc.status == Closing {


### PR DESCRIPTION
The behavior exhibited by conn.Read is reading once, rather than trying to fill the buffer. When the data transferred at a time is long enough (such as 1MB), it actually takes multiple Reads to get all the data. io.ReadFull can correctly read enough data.