### PR TITLE
# FIX - fix windows config missing

### DIFF
--- a/connect_windows.go
+++ b/connect_windows.go
@@ -14,8 +14,11 @@ import (
 func (s *Server) run() error {
 
 	var pipeBase = `\\.\pipe\`
-
-	listen, err := winio.ListenPipe(pipeBase+s.name, nil)
+	pipeConfig := winio.PipeConfig{
+		InputBufferSize:  int32(s.maxMsgSize),
+		OutputBufferSize: int32(s.maxMsgSize),
+	}
+	listen, err := winio.ListenPipe(pipeBase+s.name, &pipeConfig)
 	if err != nil {
 
 		return err


### PR DESCRIPTION
Dear maintainer, 
I guess you are probably not using the Windows operating system. The default value for the IPC pipe buffer on Windows OS is 4 KB (in my case, windows 10, it may vari on other cases)
This simple code set the size of the buffer of pipe I/O of Windows OS to maxMsgSize.
This code is expected to resolve issue #13 

I'm sorry that I'm not familiar with golang so I can't write some test code about this. 
But the problem which I faced has gone with this.

May you always be happy.
from Dos