### PR TITLE
Add ability to unblock Read() by adding ReadCtx() - same as Read() but returns on context.Done()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/q84fh/golang-ipc
+module github.com/james-barrow/golang-ipc
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/james-barrow/golang-ipc
+module github.com/q84fh/golang-ipc
 
 go 1.15
 


### PR DESCRIPTION
It would be nice to have non-blocking `Read()` call - or at least to have a possibility to un-block it (for example when more complex program, when a lot of goroutines is shutting down).

I'm proposing addition of `ReadCtx(ctx context.Context)` - it works the same as `Read()` but it accepts [context](https://pkg.go.dev/context) and returns if contexts is done.