### PR TITLE
add GOOS=js (wasm) build support

### DIFF
--- a/connect_js.go
+++ b/connect_js.go
@@ -1,0 +1,15 @@
+//go:build js
+
+package ipc
+
+// js/wasm stand-ins: there are no unix sockets or named pipes in a wasm
+// runtime, so IPC connections fail cleanly. In-process consumers talk to
+// their peer directly and never reach these paths.
+
+import "errors"
+
+var errIPCUnsupportedJS = errors.New("golang-ipc: no IPC transport on js/wasm")
+
+func (s *Server) run() error { return errIPCUnsupportedJS }
+
+func (c *Client) dial() error { return errIPCUnsupportedJS }


### PR DESCRIPTION
Adds a js/wasm platform layer (connect_js.go): Server.run and Client.dial return a clear "no IPC transport on js/wasm" error, since no unix sockets or named pipes exist in a wasm runtime. This lets applications that use golang-ipc on native targets compile unchanged for browser (wasm) builds — in use in skycoin/skywire's wasm build. Native behavior is unchanged.